### PR TITLE
Fixed additional code unit test, fixed interface method parsing/generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # typescript-cs-poco
-[![Build Status](https://travis-ci.org/Evertras/typescript-cs-poco.svg?branch=master)](https://travis-ci.org/Evertras/typescript-cs-poco)
+[![Build Status](https://travis-ci.org/ffMathy/typescript-cs-poco.svg?branch=master)](https://travis-ci.org/Evertras/typescript-cs-poco)
 
 Generates a Typescript type definition file for a C# POCO class.  Takes in a string of the file contents and spits back a string of the matching Typescript interface.  This package is intended to be wrapped for use with task runners such as Gulp and Grunt.
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function removeComments(code) {
 
 function generateInterface(className, inherits, input, isInterface, options) {
     var propertyRegex = /(?:(?:((?:public)?)|(?:private)|(?:protected)|(?:internal)|(?:protected internal)) )+(?:(virtual|readonly) )?([\w\d\._<>, \[\]]+?)(\??) ([\w\d]+)\s*(?:{\s*get;\s*(?:private\s*)?set;\s*}|;)/gm;
-    var methodRegex = /(?:(?:((?:public)?)|(?:private)|(?:protected)|(?:internal)|(?:protected internal)) )+(?:(virtual|readonly) )?(?:(async) )?(?:([\w\d\._<>, \[\]]+?) )?([\w\d]+)\(((?:.?\s?)*?)\)\s*\{(?:.?\s?)*?\}/gm;
+    var methodRegex = /(?:(?:((?:public)?)|(?:private)|(?:protected)|(?:internal)|(?:protected internal)) )+(?:(virtual|readonly) )?(?:(async) )?(?:([\w\d\._<>, \[\]]+?) )?([\w\d]+)\(((?:.?\s?)*?)\)\s*/gm;
     
     var propertyNameResolver = options && options.propertyNameResolver;
     var methodNameResolver = options && options.methodNameResolver;
@@ -192,6 +192,7 @@ function generateInterface(className, inherits, input, isInterface, options) {
             }
 
             definition += argumentDefinition;
+
 
             definition += '): ' + varType + ';\n';
 

--- a/spec/additionalCode.js
+++ b/spec/additionalCode.js
@@ -14,7 +14,7 @@ namespace MyNamespace.Domain\n\
 }\n";
 
 var expectedOutput = "interface MyPoco {\n\
-    Foo: number;\n\
+    Foo: number;\n\n\
     customStuff: MyPocoBlah;\n\
     foo(blah: number): OtherStuff;\n\
 }\n";
@@ -23,10 +23,13 @@ var pocoGen = require('../index.js');
 
 describe('typescript-cs-poco', function() {
 	it('should transform additional code correctly', function() {
-		var result = pocoGen(sampleFile, { additionalInterfaceCodeResolver: (className) =>
-"customStuff: " + className + "Blah;\n\
-foo(blah: number): OtherStuff;"
-        });
+		var result = pocoGen(
+            sampleFile,
+            {
+                additionalInterfaceCodeResolver: (leadingWhitespace, className) => "customStuff: " + className + "Blah;\n\
+    foo(blah: number): OtherStuff;"
+            }
+        );
 
         expect(result).toEqual(expectedOutput);
 	});

--- a/spec/interface.js
+++ b/spec/interface.js
@@ -9,12 +9,15 @@ namespace MyNamespace.Domain\n\
 {\n\
     public interface MyInterface\n\
     {\n\
+        string Foo(string bar);\n\
+        \
         string Name { get; set; }\n\
     }\n\
 }\n";
 
 var expectedOutput = "interface MyInterface {\n\
     Name: string;\n\
+    Foo(bar: string): string;\n\
 }\n";
 
 var pocoGen = require('../index.js');


### PR DESCRIPTION
Additional code unit test seemed to not be using the `leadingWhitespace` argument, and had the `className` as the first argument, thus not correctly getting the class name.

The interface generation tried to parse method bodies (which don't exist in interfaces, as far as I'm aware), using a runaway RegEx.